### PR TITLE
Fix a bug in --address

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	if address {
-		if s == nil {
+		if s != nil {
 			fmt.Printf("Signer: %s\n", s.address().String())
 		}
 		os.Exit(0)


### PR DESCRIPTION
Print signer address when `s` is not nil, not the other way around :)