### PR TITLE
Bump usbwallet dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # eip712sign
 
-Small golang utility used to sign EIP-712 hashes. Supports:
+Small golang utility used to sign EIP-712 typed data or hashes, and EIP-191 personal messages. Supports:
 
 - ledgers
+- trezors
 - mnemonics
 - raw private keys
 
@@ -37,8 +38,14 @@ go install github.com/base/eip712sign
 
 ```shell
 Usage of eip712sign:
+  -address
+    	Print address of signer and exit
+  -data string
+    	Data to be signed
   -hd-paths string
-    	Hierarchical deterministic derivation path for mnemonic or ledger (default "m/44'/60'/0'/0/0")
+    	Hierarchical deterministic derivation path for mnemonic, ledger, or trezor (default "m/44'/60'/0'/0/0")
+  -index int
+    	Device index to use (if multiple devices are connected)
   -ledger
     	Use ledger device for signing
   -mnemonic string
@@ -47,8 +54,14 @@ Usage of eip712sign:
     	String that prefixes the data to be signed (default "vvvvvvvv")
   -private-key string
     	Private key to use for signing
+  -skip-sender
+    	Skip adding the --sender flag to forge script commands
   -suffix string
     	String that suffixes the data to be signed (default "^^^^^^^^")
+  -text
+    	Use EIP-191 message format for signing (default is EIP-712)
+  -trezor
+    	Use trezor device for signing
   -workdir string
     	Directory in which to run the subprocess (default ".")
 ```
@@ -86,7 +99,7 @@ function printDataToSign(bytes memory data) internal pure {
 }
 ```
 
-...where `data` is 66 bytes in length.
+...where `data` is 66 bytes in length for EIP-712 hashes, or JSON for EIP-712 typed data (can optionally be hex encoded).
 
 Example output:
 

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.23.0
 toolchain go1.23.7
 
 require (
-	github.com/base/usbwallet v0.0.1
+	github.com/base/go-bip39 v1.1.0
+	github.com/base/usbwallet v0.0.2
 	github.com/decred/dcrd/hdkeychain/v3 v3.1.1
 	github.com/ethereum/go-ethereum v1.16.1
-	github.com/tyler-smith/go-bip39 v1.1.0
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,10 @@ github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjC
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
-github.com/base/usbwallet v0.0.1 h1:acXFIhJGxKMIp0Gy6i3zFvcdpvApBFbHvA2JFbr0hTM=
-github.com/base/usbwallet v0.0.1/go.mod h1:s+bJu9pqzKwF0A/B1n8kjrNOpIsookUX8IUsw5v4VXI=
+github.com/base/go-bip39 v1.1.0 h1:ely6zK09KaQbfX8wpcmN4pRXy0SbbqMT2QF45P1BNh0=
+github.com/base/go-bip39 v1.1.0/go.mod h1:grZZXX8gYycovDC4cLS/RS0DmctofwHN+MUhedYCbO0=
+github.com/base/usbwallet v0.0.2 h1:3P2nlh083/zNZhPBNE4h8DBG/rqMZH4t8OaiCDnFydU=
+github.com/base/usbwallet v0.0.2/go.mod h1:s+bJu9pqzKwF0A/B1n8kjrNOpIsookUX8IUsw5v4VXI=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -99,8 +101,6 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
-github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=

--- a/main.go
+++ b/main.go
@@ -13,13 +13,13 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/base/go-bip39"
 	"github.com/base/usbwallet"
 	"github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/exp/slices"
 )
 


### PR DESCRIPTION
Picks up support for Trezor's new signing message hash confirmation: https://github.com/base/usbwallet/pull/3.

Also switches go-bip39 from the deleted `tyler-smith` repo to `base`, and some minor README updates.